### PR TITLE
champs_revetement_Update schema_amenagements_cyclables.json

### DIFF
--- a/schema_amenagements_cyclables.json
+++ b/schema_amenagements_cyclables.json
@@ -150,6 +150,18 @@
                                     "PROVISOIRE"
                                 ]
                              },
+                            "revetement_d": {
+                                "type": "string",
+                                "description": "Revêtement de l'aménagement sur la voie de droite",
+                                "examples": [
+                                    "LISSE"
+                                ],
+                                "enum": [
+                                    "LISSE",
+                                    "RUGUEUX",
+                                    "MEUBLE"
+                                ]
+                             },
                                 "code_com_g": {
                                 "type": "string",
                                 "description": "Code INSEE de la commune (5 caractères alphanumériques) sur la voie de gauche",
@@ -239,6 +251,18 @@
                                     "PROVISOIRE"
                                 ]
                             },
+                            "revetement_g": {
+                                "type": "string",
+                                "description": "Revêtement de l'aménagement sur la voie de gauche",
+                                "examples": [
+                                    "LISSE"
+                                ],
+                                "enum": [
+                                    "LISSE",
+                                    "RUGUEUX",
+                                    "MEUBLE"
+                                ]
+                             },
                             "access_ame": {
                                 "type": "string",
                                 "description": "Accessibilité des amanégements par type de véhicule à deux roues non motorisé",


### PR DESCRIPTION
création de deux champs revetement_d et revetement_g
avec comme valeurs : LISSE , RUGUEUX et MEUBLE

Ces valeurs sont présente dans standard vélo route et voie verte de Vélo et territoire. 

La connaissance du revêtement est en effet primordiale pour qualifier les voies vertes.

Ce champs ne devrait pas être rempli obligatoirement pour les autres types d’aménagements, qui sont situé sur piste ou sur chaussée.

Edit :
Le standard Covadis de V&T définit les trois catégories de revêtements de cet manière  :

LISSE :
Revêtement de type béton bitumineux, 
béton de ciment, enrobé écologique,
asphalte qui convient au plus grand nombre 
d’usagers (tout type de vélo, roller).

RUGUEUX :
Revêtement de qualité 
intermédiaire allant du sol bien stabilisé à un enduit
praticable avec un vélo tout chemin.

MEUBLE :
Revêtement de qualité moyenne 
à médiocre moyennement stabilisé ou meuble
ne convenant qu’aux vélos tout terrain et marcheurs.
 

