### PR TITLE
Intégration des marquages au sol règlementaires

### DIFF
--- a/schema_amenagements_cyclables.json
+++ b/schema_amenagements_cyclables.json
@@ -89,6 +89,7 @@
                                     "AMENAGEMENT MIXTE PIETON VELO HORS VOIE VERTE",
                                     "CHAUSSEE A VOIE CENTRALE BANALISEE",
                                     "ACCOTEMENT REVETU HORS CVCB",
+                                    "MARQUAGES AU SOL",
                                     "AUCUN",
                                     "AUTRE"
                                 ]
@@ -178,6 +179,7 @@
                                     "AMENAGEMENT MIXTE PIETON VELO HORS VOIE VERTE",
                                     "CHAUSSEE A VOIE CENTRALE BANALISEE",
                                     "ACCOTEMENT REVENTU HORS CVCB",
+                                    "MARQUAGES AU SOL",
                                     "AUCUN",
                                     "AUTRE"
                                 ]


### PR DESCRIPTION
Ajout d'une modalité "MARQUAGES AU SOL" aux champs ame_d et ame_g pour pouvoir intégrer les aménagements cyclables prévus par le code de l'environnement pour les rues à sens unique et à une seule file (Article L228-2).
Seul les marquages répertoriées par l'instruction interministérielle sur la signalisation routière (7ème partie) peuvent être pris en compte (figurines vélo, double chevrons, figurine vélo accompagnée d’une flèche directionnelle, association de ces éléments).
Le terme "Marquages au sol" est celui utilisé dans le code.