### PR TITLE
Ajout valeur "Impasse sauf modes actifs" cat "ame_g / ame_d"

### DIFF
--- a/schema_amenagements_cyclables.json
+++ b/schema_amenagements_cyclables.json
@@ -89,6 +89,7 @@
                                     "AMENAGEMENT MIXTE PIETON VELO HORS VOIE VERTE",
                                     "CHAUSSEE A VOIE CENTRALE BANALISEE",
                                     "ACCOTEMENT REVETU HORS CVCB",
+                                    "IMPASSE MODES ACTIFS",
                                     "AUCUN",
                                     "AUTRE"
                                 ]
@@ -190,6 +191,7 @@
                                     "AMENAGEMENT MIXTE PIETON VELO HORS VOIE VERTE",
                                     "CHAUSSEE A VOIE CENTRALE BANALISEE",
                                     "ACCOTEMENT REVETU HORS CVCB",
+                                    "IMPASSE MODES ACTIFS",
                                     "AUCUN",
                                     "AUTRE"
                                 ]

--- a/schema_amenagements_cyclables.json
+++ b/schema_amenagements_cyclables.json
@@ -89,7 +89,7 @@
                                     "AMENAGEMENT MIXTE PIETON VELO HORS VOIE VERTE",
                                     "CHAUSSEE A VOIE CENTRALE BANALISEE",
                                     "ACCOTEMENT REVETU HORS CVCB",
-                                    "IMPASSE MODES ACTIFS",
+                                    "IMPASSE SAUF MODES ACTIFS",
                                     "AUCUN",
                                     "AUTRE"
                                 ]
@@ -191,7 +191,7 @@
                                     "AMENAGEMENT MIXTE PIETON VELO HORS VOIE VERTE",
                                     "CHAUSSEE A VOIE CENTRALE BANALISEE",
                                     "ACCOTEMENT REVETU HORS CVCB",
-                                    "IMPASSE MODES ACTIFS",
+                                    "IMPASSE SAUF MODES ACTIFS",
                                     "AUCUN",
                                     "AUTRE"
                                 ]


### PR DESCRIPTION
Bonjour, 

Ayant relevé plusieurs cas sur le territorire de Metz, nous souhaiterions faire une proposition d'intégration des valeurs "Impasse modes actifs" aux champs "ame_g / ame_d".

Le panneau est le suivant :
https://routes.fandom.com/wiki/Panneau_de_type_C13d
